### PR TITLE
fix(ui): input box-shadow

### DIFF
--- a/packages/app/src/components/form/NumberInput.tsx
+++ b/packages/app/src/components/form/NumberInput.tsx
@@ -10,31 +10,25 @@ interface NumberInputProps
   border?: boolean;
 }
 
-export function NumberInput({
-  border = true,
-  onChange,
-  ...props
-}: NumberInputProps) {
+export function NumberInput({ border = true, onChange, ...props }: NumberInputProps) {
   return (
-    <StyledInput
-      {...props}
-      border={border}
-      onWheel={(e) => e.currentTarget.blur()}
-      type="number"
-      pattern="^-?[0-9]\d*\.?\d*$"
-      onChange={(e) => {
-        const value = e.target.value.replace(/-|e/gi, '');
-        onChange(value);
-      }}
-    />
+    <StyledInputShadowWrapper>
+      <StyledInput
+        {...props}
+        border={border}
+        onWheel={(e) => e.currentTarget.blur()}
+        type="number"
+        pattern="^-?[0-9]\d*\.?\d*$"
+        onChange={(e) => {
+          const value = e.target.value.replace(/-|e/gi, '');
+          onChange(value);
+        }}
+      />
+    </StyledInputShadowWrapper>
   );
 }
 
-export function TextInput({
-  border = true,
-  onChange,
-  ...props
-}: NumberInputProps) {
+export function TextInput({ border = true, onChange, ...props }: NumberInputProps) {
   return (
     <StyledInput
       {...props}
@@ -47,17 +41,24 @@ export function TextInput({
   );
 }
 
+/**
+ * Adds
+ */
+const StyledInputShadowWrapper = styled.div`
+  box-shadow: 3px 3px 0px 1px #31322d;
+  border: 3px solid #1e1f1b;
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
 const StyledInput = styled.input<{ border?: boolean }>(
   ({ border }) => `
   ${border === false ? '' : ''}
-  border-radius: 0;
   width: 100%;
   background: #fefaf3;
-  box-shadow: 3px 3px 0px 1px #31322d;
-  border-radius: 8px;
   &, &:focus, &:active {
     outline: none;
-    border: 3px solid #1e1f1b;
+    border: none; /** Handled by StyledInputShadowWrapper */
   }
 `
 );


### PR DESCRIPTION
Fixes the odd no shadow observed on mobile browsers:

- Brave
- Chrome
- Safari(?)

![IMG_8859](https://user-images.githubusercontent.com/1926216/221158986-3b22f1c6-7e19-482d-990f-9e63c83bf34f.png)
