### PR TITLE
refactor: remove deposit method

### DIFF
--- a/packages/contracts/src/DCAOrder.sol
+++ b/packages/contracts/src/DCAOrder.sol
@@ -121,11 +121,6 @@ contract DCAOrder is IConditionalOrder, EIP1271Verifier, IDCAOrder {
     return true;
   }
 
-  function deposit() external returns (bool) {
-    // Transfer the capital to the order
-    return IERC20(sellToken).transferFrom(msg.sender, address(this), principal);
-  }
-
   /// @dev Cancels the order and transfers the funds back to the owner.
   function cancel() external {
     if (msg.sender != owner) {

--- a/packages/contracts/src/interfaces/IDCAOrder.sol
+++ b/packages/contracts/src/interfaces/IDCAOrder.sol
@@ -15,5 +15,4 @@ interface IDCAOrder {
     address _settlementContract,
     uint16 _fee
   ) external returns (bool);
-  function deposit() external returns (bool);
 }


### PR DESCRIPTION
Deposit is done by the OrderFactory right after the DCAOrder proxy is created, no need for a 2nd transaction to claim funds