### PR TITLE
fix: dust tokens after last order

### DIFF
--- a/packages/contracts/src/DCAOrder.sol
+++ b/packages/contracts/src/DCAOrder.sol
@@ -200,23 +200,17 @@ contract DCAOrder is IConditionalOrder, EIP1271Verifier, IDCAOrder {
   function currentSlot() public view returns (uint256 slot) {
     uint256[] memory slots = orderSlots();
 
-    // If the current time is between the last slot and the end time, return the last slot time
+    // If the current time is between the last slot and the end time, return the last slot
     // solhint-disable-next-line not-rely-on-time
     if (block.timestamp >= slots[slots.length - 1] && block.timestamp < endTime) {
       return slots[slots.length - 1];
     }
 
-    for (uint256 i = 0; i < slots.length; i++) {
-      uint256 slotEndTime = endTime;
-
-      // If the slot is not the last slot, set the end time to the next slot
-      if (i < slots.length - 1) {
-        slotEndTime = slots[i + 1];
-      }
-
-      // If the current time is between the slot start time and the end time, return the current slot time
+    // No need to reach the last slot, the last slot returns in the previous condition
+    for (uint256 i = 0; i < slots.length - 1; i++) {
+      // If the current time is between the slot start time and the next slot start time, return the current slot
       // solhint-disable-next-line not-rely-on-time
-      if (block.timestamp >= slots[i] && block.timestamp < slotEndTime) {
+      if (block.timestamp >= slots[i] && block.timestamp < slots[i + 1]) {
         slot = slots[i];
         break;
       }

--- a/packages/contracts/src/DCAOrder.sol
+++ b/packages/contracts/src/DCAOrder.sol
@@ -229,6 +229,17 @@ contract DCAOrder is IConditionalOrder, EIP1271Verifier, IDCAOrder {
   function slotSellAmount() public view returns (uint256 orderSellAmount) {
     // Execute at the specified frequency
     // Each order sellAmount is the balance of the order divided by the frequency
-    (, orderSellAmount) = SafeMath.tryDiv(amount, orderSlots().length);
+    // If the current slot is the last slot, the returned amount is the total sellToken balance
+    uint256[] memory slots = orderSlots();
+    // solhint-disable-next-line not-rely-on-time
+    uint256 currentTime = block.timestamp;
+
+    uint256 lastSlot = slots[slots.length - 1];
+
+    if (currentTime >= lastSlot && currentTime < endTime) {
+      orderSellAmount = sellToken.balanceOf(address(this));
+    } else {
+      (, orderSellAmount) = SafeMath.tryDiv(amount, slots.length);
+    }
   }
 }

--- a/packages/contracts/src/OrderFactory.sol
+++ b/packages/contracts/src/OrderFactory.sol
@@ -10,6 +10,7 @@ error ForbiddenValue();
 
 contract OrderFactory is Ownable2Step {
   using SafeERC20 for IERC20;
+
   uint16 private constant HUNDRED_PERCENT = 10000;
   uint16 public protocolFee = 5; // default 0.05% (range: 0-500 / 0-5%)
 


### PR DESCRIPTION
This PR fixes the dust tokens after last order by setting the last slot sell amount as the total amount of left tokens.