### PR TITLE
[STK-231][FIX]: Stacks not showing on gnosis chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,4 @@ out
 dist
 generated
 
-# subgraph
-subgraph.yaml
-
 bin

--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -1,0 +1,51 @@
+# Stackly Subgraphs
+
+## Description
+
+Stackly is a simple DCA (Dollar-Cost Averaging) tool that utilizes the CoW (Conditional Order
+Workflow) Protocol to place TWAP (Time-Weighted Average Price) orders. It allows users to stack
+their favorite cryptocurrencies at any frequency they choose, such as hourly, daily, weekly, or
+monthly. By following a DCA strategy, users can reduce their exposure to short-term price
+fluctuations and potentially build a more stable and profitable long-term portfolio.
+
+## Getting Started
+
+You will need a The Graph Access Token. You need a The Graph Hosted Service account, in your
+dashboard you'll find this access token.
+
+First, run the following code and it will prompt you to enter the access token
+
+```bash
+npx graph auth https://api.thegraph.com/deploy/
+```
+
+Then, you'll need to generate the Subgraph code
+
+```bash
+npx graph codegen
+```
+
+Last, now you can build the project
+
+```bash
+npx graph build
+```
+
+## Deployment
+
+You need to deploy your changes to an existing subgraph:
+
+- Go to your Hosted Service account
+- Create a new subgraph
+- Take the account and subgraph names in the following format `yourAccount/yourSubgraph`
+- Run the following command
+
+```
+npx graph deploy --node https://api.thegraph.com/deploy/ yourAccount/yourSubgraph
+```
+
+After running this command successfully, you can go to your Hosted Service account and check the
+syncing progress for your newly deployed subgraph.
+
+**NOTE:** Sync progress will never be 100% as new blocks are constantly created and your subgraph
+will keep on syncing.

--- a/packages/subgraph/src/mappings/order.ts
+++ b/packages/subgraph/src/mappings/order.ts
@@ -30,20 +30,22 @@ export function handleDCAOrderInitialized(event: Initialized): void {
   order.buyToken = createOrReturnTokenEntity(orderContract.buyToken()).id;
   order.receiver = orderContract.receiver();
 
+  let orderSlots: Array<BigInt> = [];
+  orderSlots.push(BigInt.fromI32(0));
   let protocolFee: BigInt = BigInt.fromI32(0);
-  let orderSlots;
   let orderFactoryAddress: Address = (
     event.transaction.to !== null ? event.transaction.to : Address.fromString('0x0')
   )!;
 
   const factory = OrderFactory.bind(orderFactoryAddress);
   let tryProtocolFee = factory.try_protocolFee();
-  let tryOrderSlots = factory.try_orderSlots();
   if (!tryProtocolFee.reverted) {
     protocolFee = BigInt.fromI32(tryProtocolFee.value);
   }
+
+  let tryOrderSlots = orderContract.try_orderSlots();
   if (!tryOrderSlots.reverted) {
-    orderSlots = BigInt.fromI32(tryOrderSlots.value);
+    orderSlots = tryOrderSlots.value;
   }
 
   order.amount = orderContract.amount();

--- a/packages/subgraph/src/mappings/order.ts
+++ b/packages/subgraph/src/mappings/order.ts
@@ -30,21 +30,28 @@ export function handleDCAOrderInitialized(event: Initialized): void {
   order.buyToken = createOrReturnTokenEntity(orderContract.buyToken()).id;
   order.receiver = orderContract.receiver();
 
-  let protocolFee : BigInt = BigInt.fromI32(0);
-  let orderFactoryAddress: Address = (event.transaction.to !== null ? event.transaction.to : Address.fromString("0x0"))!;
-  
+  let protocolFee: BigInt = BigInt.fromI32(0);
+  let orderSlots;
+  let orderFactoryAddress: Address = (
+    event.transaction.to !== null ? event.transaction.to : Address.fromString('0x0')
+  )!;
+
   const factory = OrderFactory.bind(orderFactoryAddress);
   let tryProtocolFee = factory.try_protocolFee();
+  let tryOrderSlots = factory.try_orderSlots();
   if (!tryProtocolFee.reverted) {
     protocolFee = BigInt.fromI32(tryProtocolFee.value);
+  }
+  if (!tryOrderSlots.reverted) {
+    orderSlots = BigInt.fromI32(tryOrderSlots.value);
   }
 
   order.amount = orderContract.amount();
   order.fee = protocolFee;
-  order.feeAmount = (order.amount.times(protocolFee)).div(HUNDRED_PERCENT.minus(protocolFee));
+  order.feeAmount = order.amount.times(protocolFee).div(HUNDRED_PERCENT.minus(protocolFee));
   order.endTime = orderContract.endTime().toI32();
   order.startTime = orderContract.startTime().toI32();
-  order.orderSlots = orderContract.orderSlots();
+  order.orderSlots = orderSlots;
   order.interval = orderContract.interval();
   order.save();
 }

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -1,0 +1,50 @@
+specVersion: 0.0.4
+schema:
+  file: ./schema.graphql
+dataSources:
+  - name: OrderFactory
+    kind: ethereum/contract
+    network: gnosis
+    source:
+      address: '0x45B91Da2834010751b17F1eadE0a5a7B64233add'
+      startBlock: 28800393
+      abi: OrderFactory
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - OrderFactory
+      abis:
+        - name: OrderFactory
+          file: ./abis/OrderFactory.json
+      eventHandlers:
+        - event: OrderCreated(indexed address)
+          handler: handleDCAOrderCreated
+      file: ./src/mappings/factory.ts
+templates:
+  - name: DCAOrder
+    kind: ethereum/contract
+    network: gnosis
+    source:
+      abi: DCAOrder
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Order
+        - Token
+      abis:
+        - name: DCAOrder
+          file: abis/DCAOrder.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: OrderFactory
+          file: ./abis/OrderFactory.json
+      eventHandlers:
+        - event: Initialized(indexed address)
+          handler: handleDCAOrderInitialized
+        - event: Cancelled(indexed address)
+          handler: handleDCAOrderCancelled
+      file: ./src/mappings/order.ts


### PR DESCRIPTION
## Fixes: [SWA-231](https://linear.app/swaprhq/issue/STK-231/stacks-not-showing-on-gnosis-chain)

# Process to debug subgraph indexing status
* Get the Subraph deployment ID (starts with Qm…). In our case, we can get this ID from https://thegraph.com/hosted-service/subgraph/swaprhq/stackly
* Go to https://graphiql-online.com/
* Enter this API: https://api.thegraph.com/index-node/graphql
* Run this query (placing the deployment ID):
```ts
{
  indexingStatuses(subgraphs: ["Qm..."]) {
    subgraph
    synced
    health
    entityCount
    fatalError {
      handler
      message
      deterministic
      block {
        hash
        number
      }
    }
    chains {
      chainHeadBlock {
        number
      }
      earliestBlock {
        number
      }
      latestBlock {
        number
      }
    }
  	nonFatalErrors {
     message
      block { number}
      handler
      
    }
  }
}
```

# Description
* Create a `try_orderSlots` approach to address the revert transaction. Read more [here](https://thegraph.com/docs/en/developing/graph-ts/api/#handling-reverted-calls)